### PR TITLE
28 impl get controller version API

### DIFF
--- a/lib/minecraft_controller_web/controllers/version.ex
+++ b/lib/minecraft_controller_web/controllers/version.ex
@@ -1,0 +1,7 @@
+defmodule MinecraftControllerWeb.Version do
+  use MinecraftControllerWeb, :controller
+
+  def get(conn, _) do
+    json(conn, %{version: "0.1.0"})
+  end
+end

--- a/lib/minecraft_controller_web/router.ex
+++ b/lib/minecraft_controller_web/router.ex
@@ -31,6 +31,8 @@ defmodule MinecraftControllerWeb.Router do
 
   scope "/api", MinecraftControllerWeb do
     pipe_through :api
+  
+    get "/version", Version, :get
 
     post "/users/login", UserController.Login, :post
 


### PR DESCRIPTION
close #28

This is a temporary implementation. The API should be removed when the deployment strategy is determined.